### PR TITLE
feat: handle options in asset chooser

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,24 +3,11 @@
     "version": "2.11.0-beta.3",
     "description": "Package to establish communication between Frontify and marketplace apps",
     "module": "dist/index.js",
+    "main": "dist/index.js",
     "files": [
         "dist"
     ],
     "types": "dist/index.d.ts",
-    "exports": {
-        ".": {
-            "import": "./dist/index.js",
-            "require": "./dist/index.js"
-        },
-        "./react": {
-            "import": "./dist/react/index.js",
-            "require": "./dist/react/index.js"
-        },
-        "./utilities": {
-            "import": "./dist/utilities/index.js",
-            "require": "./dist/utilities/index.js"
-        }
-    },
     "scripts": {
         "clean": "rimraf dist",
         "test": "jest",

--- a/src/AppBridgeNative.ts
+++ b/src/AppBridgeNative.ts
@@ -1,5 +1,15 @@
 import { IAppBridgeNative } from "./IAppBridgeNative";
-import { Asset, AssetChooserAssetChosenCallback, Color, ColorPalette, Template, TerrificEvent, User } from "./types";
+import {
+    Asset,
+    AssetChooserAssetChosenCallback,
+    AssetChooserOptions,
+    Color,
+    ColorPalette,
+    Template,
+    TemplateChooserTemplateChosenCallback,
+    TerrificEvent,
+    User,
+} from "./types";
 import { getJqueryDataByElement, getJqueryDatasetByClassName } from "./utilities/jquery";
 
 export class AppBridgeNative implements IAppBridgeNative {
@@ -155,10 +165,22 @@ export class AppBridgeNative implements IAppBridgeNative {
         return window.application.config.context.project.id;
     }
 
-    public openAssetChooser(callback: AssetChooserAssetChosenCallback): void {
+    public openAssetChooser(callback: AssetChooserAssetChosenCallback, options: AssetChooserOptions = {}): void {
         window.application.connectors.events.components.appBridge.component.onAssetChooserAssetChosen = callback;
 
-        const $assetChooser = window.application.sandbox.config.tpl.render("c-assetchooser", {});
+        const $assetChooser = window.application.sandbox.config.tpl.render("c-assetchooser", {
+            brandId: window.application.sandbox.config.context.brand.id,
+            projectTypes: options.projectTypes,
+            multiSelectionAllowed: options.multiSelection,
+            filters: [
+                ...(options.selectedValueId !== undefined
+                    ? [{ key: "id", values: [options.selectedValueId], inverted: true }]
+                    : []),
+                ...(options.extensions ? [{ key: "ext", values: options.extensions }] : []),
+                ...(options.objectTypes ? [{ key: "object_type", values: options.objectTypes }] : []),
+            ],
+        });
+
         window.application.connectors.events.notify(null, TerrificEvent.OpenModal, {
             modifier: "flex",
             $content: $assetChooser,
@@ -166,6 +188,20 @@ export class AppBridgeNative implements IAppBridgeNative {
     }
 
     public closeAssetChooser(): void {
+        window.application.connectors.events.notify(null, TerrificEvent.CloseModal, {});
+    }
+
+    public openTemplateChooser(callback: TemplateChooserTemplateChosenCallback) {
+        window.application.connectors.events.components.appBridge.component.onTemplateChooserTemplateChosen = callback;
+
+        const $templateChooser = window.application.sandbox.config.tpl.render("c-templatechooser", {});
+        window.application.connectors.events.notify(null, TerrificEvent.OpenModal, {
+            modifier: "flex",
+            $content: $templateChooser,
+        });
+    }
+
+    public closeTemplateChooser() {
         window.application.connectors.events.notify(null, TerrificEvent.CloseModal, {});
     }
 

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -1,3 +1,5 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
 export * from "./useAssetChooser";
 export * from "./useBlockSettings";
 export * from "./useEditorState";

--- a/src/react/useAssetChooser.ts
+++ b/src/react/useAssetChooser.ts
@@ -1,24 +1,14 @@
-import { AssetChooserAssetChosenCallback, TerrificEvent } from "../types/Terrific";
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { AssetChooserAssetChosenCallback, AssetChooserOptions } from "../types/Terrific";
+import { AppBridgeNative } from "../AppBridgeNative";
 
 type UseAssetChooserType = {
-    openAssetChooser: (callback: AssetChooserAssetChosenCallback) => void;
+    openAssetChooser: (callback: AssetChooserAssetChosenCallback, options: AssetChooserOptions) => void;
     closeAssetChooser: () => void;
 };
 
 export const useAssetChooser = (): UseAssetChooserType => {
-    const openAssetChooser = (callback: AssetChooserAssetChosenCallback) => {
-        window.application.connectors.events.components.appBridge.component.onAssetChooserAssetChosen = callback;
-
-        const $assetChooser = window.application.sandbox.config.tpl.render("c-assetchooser", {});
-        window.application.connectors.events.notify(null, TerrificEvent.OpenModal, {
-            modifier: "flex",
-            $content: $assetChooser,
-        });
-    };
-
-    const closeAssetChooser = () => {
-        window.application.connectors.events.notify(null, TerrificEvent.CloseModal, {});
-    };
-
-    return { openAssetChooser, closeAssetChooser };
+    const appBridge = new AppBridgeNative();
+    return { openAssetChooser: appBridge.openAssetChooser, closeAssetChooser: appBridge.closeAssetChooser };
 };

--- a/src/react/useTemplateChooser.ts
+++ b/src/react/useTemplateChooser.ts
@@ -1,4 +1,7 @@
-import { TemplateChooserTemplateChosenCallback, TerrificEvent } from "../types/Terrific";
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { AppBridgeNative } from "../AppBridgeNative";
+import { TemplateChooserTemplateChosenCallback } from "../types/Terrific";
 
 type UseTemplateChooserType = {
     openTemplateChooser: (callback: TemplateChooserTemplateChosenCallback) => void;
@@ -6,19 +9,6 @@ type UseTemplateChooserType = {
 };
 
 export const useTemplateChooser = (): UseTemplateChooserType => {
-    const openTemplateChooser = (callback: TemplateChooserTemplateChosenCallback) => {
-        window.application.connectors.events.components.appBridge.component.onTemplateChooserTemplateChosen = callback;
-
-        const $templateChooser = window.application.sandbox.config.tpl.render("c-templatechooser", {});
-        window.application.connectors.events.notify(null, TerrificEvent.OpenModal, {
-            modifier: "flex",
-            $content: $templateChooser,
-        });
-    };
-
-    const closeTemplateChooser = () => {
-        window.application.connectors.events.notify(null, TerrificEvent.CloseModal, {});
-    };
-
-    return { openTemplateChooser, closeTemplateChooser };
+    const appBridge = new AppBridgeNative();
+    return { openTemplateChooser: appBridge.openTemplateChooser, closeTemplateChooser: appBridge.closeTemplateChooser };
 };

--- a/src/types/FileExtensionSets.ts
+++ b/src/types/FileExtensionSets.ts
@@ -1,7 +1,9 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
 import { FileExtension, FileType } from ".";
 
-export const FileExtensionSets: Record<FileType, FileExtension[]> = {
-    audio: [
+export const FileExtensionSets: Record<keyof typeof FileType, FileExtension[]> = {
+    Audio: [
         FileExtension.Aac,
         FileExtension.Ac3,
         FileExtension.Aif,
@@ -14,7 +16,7 @@ export const FileExtensionSets: Record<FileType, FileExtension[]> = {
         FileExtension.Ogg,
         FileExtension.Wav,
     ],
-    documents: [
+    Documents: [
         FileExtension.Doc,
         FileExtension.Docx,
         FileExtension.Dotx,
@@ -26,7 +28,7 @@ export const FileExtensionSets: Record<FileType, FileExtension[]> = {
         FileExtension.Xlsx,
         FileExtension.Xltx,
     ],
-    images: [
+    Images: [
         FileExtension.Ai,
         FileExtension.Bmp,
         FileExtension.Dng,
@@ -43,7 +45,7 @@ export const FileExtensionSets: Record<FileType, FileExtension[]> = {
         FileExtension.Tiff,
         FileExtension.Webp,
     ],
-    videos: [
+    Videos: [
         FileExtension.Avi,
         FileExtension.Flv,
         FileExtension.M4v,
@@ -55,5 +57,5 @@ export const FileExtensionSets: Record<FileType, FileExtension[]> = {
         FileExtension.Webm,
         FileExtension.Wmv,
     ],
-    templates: [FileExtension.Indd, FileExtension.Indt, FileExtension.Sketch],
+    Templates: [FileExtension.Indd, FileExtension.Indt, FileExtension.Sketch],
 };

--- a/src/types/Terrific.ts
+++ b/src/types/Terrific.ts
@@ -1,4 +1,6 @@
-import { Asset, Template } from ".";
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { Asset, Template, FileExtension } from ".";
 
 export enum TerrificEvent {
     OpenModal = "onOpenModal",
@@ -9,5 +11,31 @@ export type AssetChooserResult = { screenData: Asset[] };
 export type TemplateChooserResult = { template: Template };
 
 export type AssetChooserAssetChosenCallback = (assetChooserResult: AssetChooserResult) => void;
-
 export type TemplateChooserTemplateChosenCallback = (templateChooserResult: TemplateChooserResult) => void;
+
+export enum AssetChooserProjectType {
+    MediaLibrary = "MEDIALIBRARY",
+    LogoLibrary = "LOGOLIBRARY",
+    IconLibrary = "ICONLIBRARY",
+    DocumentLibrary = "DOCUMENTLIBRARY",
+    TemplateLibrary = "TEMPLATELIBRARY",
+    PatternLibrary = "PATTERNLIBRARY",
+    Styleguide = "STYLEGUIDE",
+    Workspace = "WORKSPACE",
+}
+
+export enum AssetChooserObjectType {
+    File = "FILE", // Audio, Zip, ...
+    Canvas = "CANVAS",
+    ImageVideo = "IMAGE", // No distinction between images and videos in the screen table
+    TextSnippet = "TEXT_SNIPPET",
+    Url = "URL",
+}
+
+export type AssetChooserOptions = {
+    selectedValueId?: number | string;
+    projectTypes?: AssetChooserProjectType[];
+    objectTypes?: AssetChooserObjectType[];
+    multiSelection?: boolean;
+    extensions?: FileExtension[];
+};


### PR DESCRIPTION
- Add support for filters/multiselection/object type in the asset chooser
- Move template chooser to class and avoid duplication
- Export list never used and if treeshaking is working, it will not be required
