### PR TITLE
POC: use separate methods for getting / setting assets

### DIFF
--- a/src/AppBridgeNative.ts
+++ b/src/AppBridgeNative.ts
@@ -222,6 +222,53 @@ export class AppBridgeNative implements IAppBridgeNative {
         });
     }
 
+    public async setAssets(settingName: string, assets: number[]): Promise<void> {
+        if (!this.blockId) {
+            // throw new Error("You need to instanciate the App Bridge with a block id.");
+            // TODO: Replace id in url below
+        }
+
+        const response = await window.fetch(`/api/styleguide-block/175/asset/${settingName}`, {
+            method: "PUT",
+            headers: {
+                "x-csrf-token": (document.getElementsByName("x-csrf-token")[0] as HTMLMetaElement).content,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                assets: assets,
+            }),
+        });
+
+        const responseJson = await response.json();
+
+        if (!responseJson.success) {
+            throw new Error("Could not update the block assets");
+        }
+    }
+
+    public async getAssets(): Promise<any> {
+        if (!this.blockId) {
+            // throw new Error("You need to instanciate the App Bridge with a block id.");
+            // TODO: Replace id in url below
+        }
+
+        const response = await window.fetch(`/api/styleguide-block/175/asset`, {
+            method: "GET",
+            headers: {
+                "x-csrf-token": (document.getElementsByName("x-csrf-token")[0] as HTMLMetaElement).content,
+                "Content-Type": "application/json",
+            },
+        });
+
+        const responseJson = await response.json();
+
+        if (!responseJson.success) {
+            throw new Error("Could not fetch block images");
+        }
+
+        return responseJson;
+    }
+
     public closeAssetChooser(): void {
         window.application.connectors.events.notify(null, TerrificEvent.CloseModal, {});
     }

--- a/src/AppBridgeNativeMock.ts
+++ b/src/AppBridgeNativeMock.ts
@@ -4,6 +4,12 @@ import { IAppBridgeNative } from "./IAppBridgeNative";
 import { Asset, Color, ColorPalette, User } from "./types";
 
 export class AppBridgeNativeMock implements IAppBridgeNative {
+    getAssets(): Promise<void> {
+        return Promise.resolve(undefined);
+    }
+    setAssets(settingName: string, assets: number[]): Promise<void> {
+        return Promise.resolve(undefined);
+    }
     constructor(public blockId?: number, public sectionId?: number) {}
 
     getAssetById(assetId: number): Promise<Asset> {

--- a/src/IAppBridgeNative.ts
+++ b/src/IAppBridgeNative.ts
@@ -22,6 +22,8 @@ export interface IAppBridgeNative {
     getEditorState(): boolean;
     getProjectId(): number;
     openAssetChooser(callback: AssetChooserAssetChosenCallback, options?: AssetChooserOptions): void;
+    setAssets(settingName: string, assets: number[]): Promise<void>;
+    getAssets(): Promise<void>;
     closeAssetChooser(): void;
     openTemplateChooser(callback: TemplateChooserTemplateChosenCallback): void;
     closeTemplateChooser(): void;


### PR DESCRIPTION
* Meant to be used together with the [new block-endpoints](https://github.com/Frontify/clarify/pull/7563)
* `getAssets` should be called by the block
`appBridge.getAssets().then((assets) => {setIconUrl(assets.generic_url);setIconAltText('Callout Block Icon: ${assets.title}');});`
* `setAssets` will be called by `AssetInputBlock`
 `appBridge.setAssets(block.id, [resultId]);`