### PR TITLE
refactor: useBlockSettings to use custom event instead of window

### DIFF
--- a/src/AppBridgeNative.ts
+++ b/src/AppBridgeNative.ts
@@ -275,7 +275,9 @@ export class AppBridgeNative implements IAppBridgeNative {
     }
 
     public getEditorState(): boolean {
-        return !!document.querySelector('.js-co-powerbar__sg-edit.state-active');
+        return (
+            this.getBlockReferenceToken() === null && !!document.querySelector('.js-co-powerbar__sg-edit.state-active')
+        );
     }
 
     public getBlockReferenceToken(): string | null {

--- a/src/AppBridgeNative.ts
+++ b/src/AppBridgeNative.ts
@@ -182,7 +182,7 @@ export class AppBridgeNative implements IAppBridgeNative {
         return responseJson.palettes;
     }
 
-    public async getBlockSettings<T = Record<string, unknown>>(): Promise<T> {
+    private async getDocumentBlockSettings<T = Record<string, unknown>>(): Promise<T> {
         if (!this.blockId) {
             throw new Error('You need to instanciate the App Bridge with a block id.');
         }
@@ -208,7 +208,32 @@ export class AppBridgeNative implements IAppBridgeNative {
         return responseJson.settings as T;
     }
 
-    public async updateBlockSettings<T = Record<string, unknown>>(newSettings: T): Promise<void> {
+    private async getGuidelineBlockSettings<T = Record<string, unknown>>(): Promise<T> {
+        const { result } = await HttpClient.get<{ settings: T }>(`/api/guideline-block/${this.blockId}`);
+        if (!result.success) {
+            throw new Error('Could not get the block settings');
+        }
+
+        return result.data.settings;
+    }
+
+    private isNewGuideline(): boolean {
+        return !!window.application.sandbox.config.context.guideline;
+    }
+
+    public async getBlockSettings<T = Record<string, unknown>>(): Promise<T> {
+        if (!this.blockId) {
+            throw new Error('You need to instanciate the App Bridge with a block id.');
+        }
+
+        if (!this.isNewGuideline()) {
+            return this.getDocumentBlockSettings();
+        }
+
+        return this.getGuidelineBlockSettings();
+    }
+
+    private async updateDocumentBlockSettings<T = Record<string, unknown>>(newSettings: T): Promise<void> {
         if (!this.blockId) {
             throw new Error('You need to instanciate the App Bridge with a block id.');
         }
@@ -230,14 +255,36 @@ export class AppBridgeNative implements IAppBridgeNative {
         }
     }
 
-    public getEditorState(): boolean {
+    private async updateGuidelineBlockSettings<T = Record<string, unknown>>(newSettings: T): Promise<void> {
+        const { result } = await HttpClient.patch(`/api/guideline-block/${this.blockId}`, { settings: newSettings });
+        if (!result.success) {
+            throw new Error('Could not update the block settings');
+        }
+    }
+
+    public async updateBlockSettings<T = Record<string, unknown>>(newSettings: T): Promise<void> {
         if (!this.blockId) {
             throw new Error('You need to instanciate the App Bridge with a block id.');
         }
 
-        const blockElement = document.querySelector(`[data-block="${this.blockId}"]`) as HTMLElement;
-        const isReferencedBlock = blockElement.dataset.referenceToken !== undefined ? true : false;
-        return !isReferencedBlock && document.body.classList.contains('editor-enabled');
+        if (!this.isNewGuideline()) {
+            return this.updateDocumentBlockSettings(newSettings);
+        }
+
+        return this.updateGuidelineBlockSettings(newSettings);
+    }
+
+    public getEditorState(): boolean {
+        return !!document.querySelector('.js-co-powerbar__sg-edit.state-active');
+    }
+
+    public getBlockReferenceToken(): string | null {
+        if (!this.blockId) {
+            throw new Error('You need to instanciate the App Bridge with a block id.');
+        }
+
+        const blockElement = document.querySelector(`[data-block="${this.blockId}"]`) as HTMLElement | null;
+        return blockElement?.dataset?.referenceToken ?? null;
     }
 
     public getProjectId(): number {

--- a/src/react/useBlockAssets.ts
+++ b/src/react/useBlockAssets.ts
@@ -30,11 +30,11 @@ export const useBlockAssets = (appBridge: IAppBridgeNative) => {
             };
             mountingFetch();
 
-            window.emitter.on('StyleguideBlockAssetsUpdated', updateBlockAssetsFromEvent);
+            window.emitter.on('AppBridge:BlockAssetsUpdated', updateBlockAssetsFromEvent);
         }
 
         return () => {
-            window.emitter.off('StyleguideBlockAssetsUpdated', updateBlockAssetsFromEvent);
+            window.emitter.off('AppBridge:BlockAssetsUpdated', updateBlockAssetsFromEvent);
         };
     }, [appBridge]);
 
@@ -53,7 +53,7 @@ export const useBlockAssets = (appBridge: IAppBridgeNative) => {
             await appBridge.addAssetIdsToBlockAssetKey(key, assetIdsToAdd);
         }
 
-        window.emitter.emit('StyleguideBlockAssetsUpdated', {
+        window.emitter.emit('AppBridge:BlockAssetsUpdated', {
             blockId,
             blockAssets: await appBridge.getBlockAssets(),
         });

--- a/src/react/useBlockSettings.ts
+++ b/src/react/useBlockSettings.ts
@@ -4,6 +4,11 @@ import { useEffect, useState } from 'react';
 import { IAppBridgeNative } from '../types/IAppBridgeNative';
 import { compareObjects } from '../utilities/object';
 
+export type BlockSettingsUpdateEvent<T> = {
+    blockId: number;
+    blockSettings: T;
+};
+
 export const useBlockSettings = <T = Record<string, unknown>>(
     appBridge: IAppBridgeNative,
 ): [T, (newSettings: Partial<T>) => Promise<void>] => {
@@ -18,7 +23,7 @@ export const useBlockSettings = <T = Record<string, unknown>>(
     // Fetch the block settings on mount.
     // And add listener for block settings updates.
     useEffect(() => {
-        const updateBlockSettingsFromEvent = (event: { blockId: number; blockSettings: unknown }) => {
+        const updateBlockSettingsFromEvent = (event: BlockSettingsUpdateEvent<T>) => {
             if (event.blockId === blockId && !compareObjects(event.blockSettings, blockSettings)) {
                 setBlockSettings({ ...blockSettings, ...(event.blockSettings as Partial<T>) });
             }

--- a/src/react/useBlockSettings.ts
+++ b/src/react/useBlockSettings.ts
@@ -31,18 +31,18 @@ export const useBlockSettings = <T = Record<string, unknown>>(
             };
             mountingFetch();
 
-            window.emitter.on('StyleguideBlockSettingsUpdated', updateBlockSettingsFromEvent);
+            window.emitter.on('AppBridge:BlockSettingsUpdated', updateBlockSettingsFromEvent);
         }
 
         return () => {
-            window.emitter.off('StyleguideBlockSettingsUpdated', updateBlockSettingsFromEvent);
+            window.emitter.off('AppBridge:BlockSettingsUpdated', updateBlockSettingsFromEvent);
         };
     }, [appBridge]);
 
     const updateBlockSettings = async (blockSettings: Partial<T>) => {
         try {
             await appBridge.updateBlockSettings(blockSettings);
-            window.emitter.emit('StyleguideBlockSettingsUpdated', {
+            window.emitter.emit('AppBridge:BlockSettingsUpdated', {
                 blockId,
                 blockSettings: await appBridge.getBlockSettings<T>(),
             });

--- a/src/react/useEditorState.ts
+++ b/src/react/useEditorState.ts
@@ -1,3 +1,5 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
 import { useEffect, useState } from 'react';
 import { IAppBridgeNative } from '../types/IAppBridgeNative';
 import { AppBridgeNative } from '../AppBridgeNative';
@@ -17,7 +19,13 @@ export const useEditorState = (appBridge?: IAppBridgeNative): boolean => {
             }
         });
 
-        mutationObserver.observe(document.body, { attributes: true });
+        const editButtonElement = document.querySelector('.js-co-powerbar__sg-edit');
+        if (!editButtonElement) {
+            console.error('Can not find the editing state');
+            return;
+        }
+
+        mutationObserver.observe(editButtonElement, { attributes: true });
 
         return () => {
             mutationObserver.disconnect();

--- a/src/tests/withAppBridgeStubs.tsx
+++ b/src/tests/withAppBridgeStubs.tsx
@@ -14,11 +14,7 @@ type GetStubbedAppBridgeProps = {
     closeAssetChooser?: () => void;
 };
 
-const stubWindowObject = (
-    windowObject: Window | Cypress.AUTWindow,
-    options: { blockId: number; blockSettings: Record<string, unknown> },
-) => {
-    windowObject.blockSettings = { [options.blockId]: options.blockSettings };
+const stubWindowObject = (windowObject: Window | Cypress.AUTWindow) => {
     windowObject.emitter = {
         emit: () => null,
         off: () => null,
@@ -39,12 +35,11 @@ const getStubbedAppBridge = ({
     closeAssetChooser = () => null,
 }: GetStubbedAppBridgeProps): IAppBridgeNative => {
     const appBridge = new AppBridgeNativeDummy();
-    const blockId = appBridge.getBlockId() ?? 0;
 
     if (cy) {
-        cy.window().then((window) => stubWindowObject(window, { blockId, blockSettings }));
+        cy.window().then((window) => stubWindowObject(window));
     } else {
-        stubWindowObject(window, { blockId, blockSettings });
+        stubWindowObject(window);
     }
 
     stub(appBridge, 'closeAssetChooser').callsFake(closeAssetChooser);

--- a/src/window.d.ts
+++ b/src/window.d.ts
@@ -12,7 +12,6 @@ declare global {
                 upload: string;
             };
         };
-        blockSettings: Record<number, Record<string, unknown>>;
         application: {
             config: {
                 context: {
@@ -73,7 +72,6 @@ declare global {
 
 declare namespace Cypress {
     interface AUTWindow {
-        blockSettings: Record<number, Record<string, unknown>>;
         emitter: Emitter<{
             StyleguideBlockSettingsUpdated: {
                 blockId: number;

--- a/src/window.d.ts
+++ b/src/window.d.ts
@@ -51,11 +51,16 @@ declare global {
                         brand: {
                             id: number;
                         };
+                        guideline: any;
                     };
                 };
             };
         };
         emitter: Emitter<{
+            StyleguideBlockSettingsUpdated: {
+                blockId: number;
+                blockSettings: unknown;
+            };
             StyleguideBlockAssetsUpdated: {
                 blockId: number;
                 blockAssets: Record<string, Asset[]>;
@@ -70,6 +75,10 @@ declare namespace Cypress {
     interface AUTWindow {
         blockSettings: Record<number, Record<string, unknown>>;
         emitter: Emitter<{
+            StyleguideBlockSettingsUpdated: {
+                blockId: number;
+                blockSettings: unknown;
+            };
             StyleguideBlockAssetsUpdated: {
                 blockId: number;
                 blockAssets: Record<string, Asset[]>;

--- a/src/window.d.ts
+++ b/src/window.d.ts
@@ -56,11 +56,11 @@ declare global {
             };
         };
         emitter: Emitter<{
-            StyleguideBlockSettingsUpdated: {
+            'AppBridge:BlockSettingsUpdated': {
                 blockId: number;
                 blockSettings: unknown;
             };
-            StyleguideBlockAssetsUpdated: {
+            'AppBridge:BlockAssetsUpdated': {
                 blockId: number;
                 blockAssets: Record<string, Asset[]>;
             };
@@ -73,11 +73,11 @@ declare global {
 declare namespace Cypress {
     interface AUTWindow {
         emitter: Emitter<{
-            StyleguideBlockSettingsUpdated: {
+            'AppBridge:BlockSettingsUpdated': {
                 blockId: number;
                 blockSettings: unknown;
             };
-            StyleguideBlockAssetsUpdated: {
+            'AppBridge:BlockAssetsUpdated': {
                 blockId: number;
                 blockAssets: Record<string, Asset[]>;
             };

--- a/src/window.d.ts
+++ b/src/window.d.ts
@@ -2,6 +2,7 @@
 
 import { AssetChooserAssetChosenCallback, TerrificEvent } from './types/Terrific';
 import type { Emitter } from 'mitt';
+import { BlockSettingsUpdateEvent } from './react';
 
 declare global {
     interface Window {
@@ -56,10 +57,7 @@ declare global {
             };
         };
         emitter: Emitter<{
-            'AppBridge:BlockSettingsUpdated': {
-                blockId: number;
-                blockSettings: unknown;
-            };
+            'AppBridge:BlockSettingsUpdated': BlockSettingsUpdateEvent;
             'AppBridge:BlockAssetsUpdated': {
                 blockId: number;
                 blockAssets: Record<string, Asset[]>;


### PR DESCRIPTION
To test:
Link App Bridge on clarify and in a block
- app-bridge: `git checkout origin/refactor/change-useblocksettings && pnpm build`
- clarify: `pnpm link ../app-bridge`
- one guideline-block: `pnpm link ../../../app-bridge`